### PR TITLE
Set user-defined stabilizer configuration in the controller reset

### DIFF
--- a/include/lipm_walking/Controller.h
+++ b/include/lipm_walking/Controller.h
@@ -318,6 +318,7 @@ private: /* hidden from FSM states */
   std::shared_ptr<mc_tasks::lipm_stabilizer::StabilizerTask> stabilizer_;
   mc_rbdyn::lipm_stabilizer::StabilizerConfiguration
       defaultStabilizerConfig_; /**< Default configuration of the stabilizer */
+  mc_rbdyn::lipm_stabilizer::StabilizerConfiguration stabiConfig_;
   ModelPredictiveControl mpc_; /**< MPC problem solver used for walking pattern generation */
   mc_rtc::Configuration mpcConfig_; /**< Configuration dictionary for the walking pattern generator */
   mc_planning::Pendulum


### PR DESCRIPTION
It's necessary because  the stabilizer config is overwritten in the StabilizerTask reset.
https://github.com/jrl-umi3218/mc_rtc/blob/master/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp#L110

For example, without this patch, the following configuration is not reflected: https://github.com/mmurooka/lipm_walking_controller/commit/a149090275edea95e8f2c1ee5f6117cff3bba4c9