### PR TITLE
[bugfix] transform the velocity and acceleration of swing foot to surface frame

### DIFF
--- a/src/states/SingleSupport.cpp
+++ b/src/states/SingleSupport.cpp
@@ -135,8 +135,10 @@ void states::SingleSupport::updateSwingFoot()
     {
       swingFoot_.integrate(dt);
       swingFootTask->target(swingFoot_.pose());
-      swingFootTask->refVelB(swingFoot_.vel());
-      swingFootTask->refAccel(swingFoot_.accel());
+      // T_0_s transforms a MotionVecd variable from world to surface frame
+      sva::PTransformd T_0_s(swingFootTask->surfacePose().rotation());
+      swingFootTask->refVelB(T_0_s * swingFoot_.vel());
+      swingFootTask->refAccel(T_0_s * swingFoot_.accel());
     }
     else
     {


### PR DESCRIPTION
This closes https://github.com/jrl-umi3218/lipm_walking_controller/issues/29.

### Verification by simulation

In the choreonoid simulation of HRP5P, the robot first turned 180 degrees on the spot and then walked forward (x negative direction). The graph shows the x position of the swing foot during walking forward. By the change in PR, the actual position now follows the target position well.

#### Without PR
![before](https://user-images.githubusercontent.com/6636600/104845612-b3c4b680-5919-11eb-9aa6-47d963a8e233.png)

#### With PR
![after](https://user-images.githubusercontent.com/6636600/104845613-b58e7a00-5919-11eb-8f71-c99a03e8630d.png)
