### PR TITLE
[Tsuru] remove ghost footstep cache. Now the robot walk more safely.

### DIFF
--- a/src/states/Standing.cpp
+++ b/src/states/Standing.cpp
@@ -48,8 +48,8 @@ void states::Standing::configure(const mc_rtc::Configuration & config)
 void states::Standing::start()
 {
   auto & ctl = controller();
-  auto & supportContact = ctl.supportContact();
-  auto & targetContact = ctl.targetContact();
+  supportContact_ = ctl.supportContact();
+  targetContact_ = ctl.targetContact();
 
   controller().datastore().remove("Plugin::FSP::Plan");
   controller().datastore().make<bool>("Plugin::FSP::Request", true);
@@ -59,19 +59,19 @@ void states::Standing::start()
   leftFootRatio_ = ctl.leftFootRatio();
   startWalking_ = startWalking_ || ctl.config()("autoplay", false);
   ctl.isWalking = false;
-  if(supportContact.surfaceName == "RightFootCenter")
+  if(supportContact_.surfaceName == "RightFootCenter")
   {
-    leftFootContact_ = targetContact;
-    rightFootContact_ = supportContact;
+    leftFootContact_ = targetContact_;
+    rightFootContact_ = supportContact_;
   }
-  else if(supportContact.surfaceName == "LeftFootCenter")
+  else if(supportContact_.surfaceName == "LeftFootCenter")
   {
-    leftFootContact_ = supportContact;
-    rightFootContact_ = targetContact;
+    leftFootContact_ = supportContact_;
+    rightFootContact_ = targetContact_;
   }
   else
   {
-    mc_rtc::log::error_and_throw<std::invalid_argument>("Unknown surface name: {}", supportContact.surfaceName);
+    mc_rtc::log::error_and_throw<std::invalid_argument>("Unknown surface name: {}", supportContact_.surfaceName);
   }
 
   if(ctl.isLastDSP())
@@ -120,7 +120,7 @@ void states::Standing::start()
     gui()->addElement({"Walking", "Main"}, ComboInput("Footstep plan", ctl.planInterpolator.availablePlans(),
                                                       [&ctl]() { return ctl.plan.name; },
                                                       [this](const std::string & name) { updatePlan(name); }));
-    gui()->addElement({"Walking", "Main"}, Button((supportContact.id == 0) ? "Start walking" : "Resume walking",
+    gui()->addElement({"Walking", "Main"}, Button((supportContact_.id == 0) ? "Start walking" : "Resume walking",
                                                   [this]() { startWalking(); }));
     gui()->addElement({"Standing"},
                       NumberInput("CoM target [0-1]", [this]() { return std::round(leftFootRatio_ * 10.) / 10.; },
@@ -169,7 +169,7 @@ void states::Standing::runState()
   double K = COM_STIFFNESS;
   double D = 2 * std::sqrt(K);
   Eigen::Vector3d comdd = K * (comTarget - com_i) - D * comd_i;
-  Eigen::Vector3d n = ctl.supportContact().normal();
+  Eigen::Vector3d n = supportContact_.normal();
   double lambda = n.dot(comdd + mc_rtc::constants::gravity) / n.dot(com_i - cop_f);
   Eigen::Vector3d zmp = com_i - (mc_rtc::constants::gravity + comdd) / lambda;
 
@@ -196,16 +196,16 @@ void states::Standing::checkPlanUpdates()
  
       // TODO : I found that support contact is changing randomly in standing state. To resume walking naturally, please make the contact stable.
       
-      //LOG_ERROR("current contact : " << ctl.supportContact().surfaceName);
+      LOG_ERROR("current contact : " << supportContact_.surfaceName);
       
-      // if(ctl.supportContact().surfaceName == "RightFootCenter")
-      // {
-      //   ctl.plan.reset(0); //restart walking on left foot
-      // }
-      // else// if(ctl.supportContact().surfaceName == "LeftFootCenter")
-      // {
-      //   ctl.plan.reset(1); //restart walking on right foot
-      // }
+      if(supportContact_.surfaceName == "RightFootCenter")
+      {
+        ctl.plan.reset(0); //restart walking on left foot
+      }
+      else// if(ctl.supportContact().surfaceName == "LeftFootCenter")
+      {
+        ctl.plan.reset(1); //restart walking on right foot
+      }
 
       controller().datastore().remove("Plugin::FSP::Plan");
       LOG_ERROR("Standing::Update::FootStepPlan")
@@ -254,7 +254,7 @@ bool states::Standing::checkTransitions()
     return false;
   }
 
-  ctl.mpc().contacts(ctl.supportContact(), ctl.targetContact(), ctl.nextContact());
+  ctl.mpc().contacts(supportContact_, targetContact_, ctl.nextContact());
   ctl.mpc().phaseDurations(0., ctl.plan.initDSPDuration(), ctl.singleSupportDuration());
   if(ctl.updatePreview())
   {

--- a/src/states/Standing.cpp
+++ b/src/states/Standing.cpp
@@ -192,11 +192,13 @@ void states::Standing::checkPlanUpdates()
       LOG_INFO("Current LeftFootCenter: " << X_0_lf.translation().transpose())
       LOG_INFO("Current RightFootCenter: " << X_0_rf.translation().transpose())
       ctl.plan.updateInitialTransform(X_0_lf, X_0_rf, 0);
-      ctl.plan.rewind();
- 
-      // TODO : I found that support contact is changing randomly in standing state. To resume walking naturally, please make the contact stable.
       
-      LOG_ERROR("current contact : " << supportContact_.surfaceName);
+      // I found that support contact is changing randomly in original standing state. 
+      // To resume walking naturally, I memorized the landing foot in start() function.
+      
+      //ctl.plan.rewind(); 
+
+      //LOG_ERROR("current contact : " << supportContact_.surfaceName);
       
       if(supportContact_.surfaceName == "RightFootCenter")
       {

--- a/src/states/Standing.cpp
+++ b/src/states/Standing.cpp
@@ -51,6 +51,9 @@ void states::Standing::start()
   auto & supportContact = ctl.supportContact();
   auto & targetContact = ctl.targetContact();
 
+  controller().datastore().remove("Plugin::FSP::Plan");
+  controller().datastore().make<bool>("Plugin::FSP::Request", true);
+
   planChanged_ = false;
   lastInterpolatorIter_ = ctl.planInterpolator.nbIter;
   leftFootRatio_ = ctl.leftFootRatio();
@@ -190,6 +193,20 @@ void states::Standing::checkPlanUpdates()
       LOG_INFO("Current RightFootCenter: " << X_0_rf.translation().transpose())
       ctl.plan.updateInitialTransform(X_0_lf, X_0_rf, 0);
       ctl.plan.rewind();
+ 
+      // TODO : I found that support contact is changing randomly in standing state. To resume walking naturally, please make the contact stable.
+      
+      //LOG_ERROR("current contact : " << ctl.supportContact().surfaceName);
+      
+      // if(ctl.supportContact().surfaceName == "RightFootCenter")
+      // {
+      //   ctl.plan.reset(0); //restart walking on left foot
+      // }
+      // else// if(ctl.supportContact().surfaceName == "LeftFootCenter")
+      // {
+      //   ctl.plan.reset(1); //restart walking on right foot
+      // }
+
       controller().datastore().remove("Plugin::FSP::Plan");
       LOG_ERROR("Standing::Update::FootStepPlan")
     }

--- a/src/states/Standing.h
+++ b/src/states/Standing.h
@@ -108,6 +108,10 @@ private:
   std::vector<std::string> autoplay_plans_; /** Plans to play if config(autoplay) = true */
   double leftFootRatio_; /**< Left foot ratio from GUI input */
   unsigned lastInterpolatorIter_; /**< Last iteration number of the plan interpolator */
+
+  /* Tsuru add */
+  lipm_walking::Contact supportContact_;  //Keep the last contact foot stably.
+  lipm_walking::Contact targetContact_; //Keep the last contact foot stably.
 };
 
 } // namespace states


### PR DESCRIPTION
Hello, Dr.Tanguy.
I detected the cause of my biggest problem, the robot sometimes executes an old footstep.
Please merge this modification, and combine the latest version of my mc_plugin_footstep_plan and Online Footstep Planner.
(At least, the robot is walking now. Even after the video submission might be enough.)